### PR TITLE
Implement Pyth price feed

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -7,3 +7,8 @@
 - Created .env.example
 
 Implemented base structure with config loader and price fetch from Jupiter API.
+
+## Step 2
+- Added Pyth network price feed using `pythclient.HermesClient`.
+- Updated `requirements.txt` with `pythclient` dependency.
+- Expanded `main.py` to display prices from Jupiter and Pyth.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ aiohttp
 websockets
 python-dotenv
 rich
+pythclient

--- a/src/data/pyth_feed.py
+++ b/src/data/pyth_feed.py
@@ -1,0 +1,18 @@
+from typing import Optional
+from pythclient.hermes import HermesClient
+
+# Pyth price feed ID for SOL/USD on mainnet
+SOL_FEED_ID = "J83mCTdkBStKF7yD1ewtg7d6cgt1YG11E9cujiFFJmD9"  # default feed id
+
+async def fetch_pyth_sol_price() -> Optional[float]:
+    """Fetch SOL/USD price from Pyth using Hermes HTTP endpoint."""
+    client = HermesClient([SOL_FEED_ID])
+    try:
+        prices = await client.get_all_prices(version=2)
+        feed = prices.get(SOL_FEED_ID)
+        if not feed:
+            return None
+        price = feed["price"].price * (10 ** feed["price"].expo)
+        return float(price)
+    except Exception:
+        return None

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,22 @@
 import asyncio
 from rich import print
+
 from src.data.jupiter_quote import fetch_sol_price
+from src.data.pyth_feed import fetch_pyth_sol_price
 
 async def main():
-    price = await fetch_sol_price()
-    if price is not None:
-        print(f"SOL price: {price} USD")
+    jup_price = await fetch_sol_price()
+    pyth_price = await fetch_pyth_sol_price()
+
+    if jup_price is not None:
+        print(f"[green]Jupiter price:[/] {jup_price} USD")
     else:
-        print("Failed to fetch price")
+        print("[red]Failed to fetch Jupiter price[/]")
+
+    if pyth_price is not None:
+        print(f"[green]Pyth price:[/] {pyth_price} USD")
+    else:
+        print("[red]Failed to fetch Pyth price[/]")
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- implement `fetch_pyth_sol_price` using HermesClient
- show Pyth and Jupiter prices in the example
- log new progress in development log
- add `pythclient` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851b8399abc8320b0c5527675640f70