### PR TITLE
Implement simple strategy and indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cd solana-ai-bot
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env   # añade tus claves
+python src/main.py     # ejecuta demo de precios y señal
 ```
 
 **`requirements.txt` mínimo**
@@ -122,9 +123,11 @@ MAX_DRAWDOWN_PCT=20
 | **Pyth Network** | Precio fiable on-chain (SOL/USD) | WebSocket vía `pyth-client-py` |
 
 ### 5.2 Strategy
-- **Indicadores técnicos (EMA 12/50, RSI 14, Bollinger 20/2)**  
-- Filtro de volumen (evita operar con liquidez baja)  
-- Validación IA: modelo ligero (random-forest) que aprende qué señales históricas fueron rentables  
+- **Indicadores técnicos (EMA 12/50, RSI 14, Bollinger 20/2)**
+- Implementación en `strategy/indicators.py` y señales básicas en
+  `strategy/simple_strategy.py`.
+- Filtro de volumen (evita operar con liquidez baja)
+- Validación IA: modelo ligero (random-forest) que aprende qué señales históricas fueron rentables
 
 ### 5.3 Execution
 - **Jupiter Python SDK** genera transacción en base64 lista para firmar  

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -12,3 +12,9 @@ Implemented base structure with config loader and price fetch from Jupiter API.
 - Added Pyth network price feed using `pythclient.HermesClient`.
 - Updated `requirements.txt` with `pythclient` dependency.
 - Expanded `main.py` to display prices from Jupiter and Pyth.
+
+## Step 3
+- Implemented EMA, RSI and Bollinger Bands helpers in `strategy/indicators.py`.
+- Created `strategy/simple_strategy.py` with a basic signal generator.
+- Updated `main.py` to collect recent prices and print the generated signal.
+- Documented new modules in README.

--- a/src/main.py
+++ b/src/main.py
@@ -3,20 +3,31 @@ from rich import print
 
 from src.data.jupiter_quote import fetch_sol_price
 from src.data.pyth_feed import fetch_pyth_sol_price
+from src.strategy.simple_strategy import generate_signal
+
+
+async def gather_prices(count: int = 10, interval: float = 1.0):
+    """Fetch SOL prices multiple times and return the list."""
+    prices = []
+    for _ in range(count):
+        price = await fetch_sol_price()
+        if price is not None:
+            prices.append(price)
+            print(f"[cyan]Jupiter price:[/] {price} USD")
+        else:
+            print("[red]Failed to fetch Jupiter price[/]")
+        await asyncio.sleep(interval)
+    return prices
+
 
 async def main():
-    jup_price = await fetch_sol_price()
+    prices = await gather_prices()
     pyth_price = await fetch_pyth_sol_price()
-
-    if jup_price is not None:
-        print(f"[green]Jupiter price:[/] {jup_price} USD")
-    else:
-        print("[red]Failed to fetch Jupiter price[/]")
-
     if pyth_price is not None:
-        print(f"[green]Pyth price:[/] {pyth_price} USD")
-    else:
-        print("[red]Failed to fetch Pyth price[/]")
+        print(f"[green]Latest Pyth price:[/] {pyth_price} USD")
+    signal = generate_signal(prices)
+    print(f"[bold yellow]Generated signal:[/] {signal}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/src/strategy/indicators.py
+++ b/src/strategy/indicators.py
@@ -1,0 +1,31 @@
+from typing import List, Tuple
+import pandas as pd
+
+
+def ema(prices: List[float], span: int) -> float:
+    """Calculate exponential moving average for the given span."""
+    series = pd.Series(prices)
+    return series.ewm(span=span, adjust=False).mean().iloc[-1]
+
+
+def rsi(prices: List[float], window: int = 14) -> float:
+    """Calculate Relative Strength Index (RSI)."""
+    series = pd.Series(prices)
+    delta = series.diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = -delta.where(delta < 0, 0.0)
+    avg_gain = gain.rolling(window=window).mean()
+    avg_loss = loss.rolling(window=window).mean()
+    rs = avg_gain / avg_loss
+    rsi = 100 - (100 / (1 + rs))
+    return rsi.iloc[-1]
+
+
+def bollinger_bands(prices: List[float], window: int = 20, num_std: float = 2) -> Tuple[float, float]:
+    """Return upper and lower Bollinger Bands."""
+    series = pd.Series(prices)
+    sma = series.rolling(window=window).mean()
+    std = series.rolling(window=window).std()
+    upper = sma + num_std * std
+    lower = sma - num_std * std
+    return upper.iloc[-1], lower.iloc[-1]

--- a/src/strategy/simple_strategy.py
+++ b/src/strategy/simple_strategy.py
@@ -1,0 +1,22 @@
+from typing import List
+from .indicators import ema, rsi, bollinger_bands
+
+
+def generate_signal(prices: List[float]) -> str:
+    """Return BUY, SELL or HOLD based on simple indicator rules."""
+    if len(prices) < 50:
+        return "HOLD"
+
+    last_price = prices[-1]
+    ema12 = ema(prices, 12)
+    ema50 = ema(prices, 50)
+    rsi_val = rsi(prices, 14)
+    upper_bb, lower_bb = bollinger_bands(prices)
+
+    if rsi_val > 70 and last_price >= upper_bb:
+        return "SELL"
+    if rsi_val < 30 and last_price <= lower_bb:
+        return "BUY"
+    if ema12 > ema50 and rsi_val < 70:
+        return "HOLD"
+    return "HOLD"


### PR DESCRIPTION
## Summary
- add EMA/RSI/Bollinger indicators
- add `simple_strategy` module with basic signal generator
- extend example in `main.py` to output trading signal
- document new modules in README and devlog
- update quickstart instructions

## Testing
- `python -m py_compile src/main.py src/strategy/indicators.py src/strategy/simple_strategy.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement jupiter-python-sdk>=0.4)*
- `python src/main.py` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_6851b9fd0ed48320b3096e45909d775e