### PR TITLE
Add portfolio tracker and logger utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,13 @@ MAX_DRAWDOWN_PCT=20
 - Validación IA: modelo ligero (random-forest) que aprende qué señales históricas fueron rentables
 
 ### 5.3 Execution
-- **Jupiter Python SDK** genera transacción en base64 lista para firmar  
-- Firmado con `solana.Keypair` + `solders.VersionedTransaction`  
-- Envío via `client.send_raw_transaction`  
-- Gestor de cartera para actualizar balances y P/L  
+- Implementación en `execution/jupiter_client.py` para solicitar cotizaciones a Jupiter (stub si no hay red).
+- `execution/portfolio.py` mantiene el saldo de SOL/USDC y calcula P/L.
+- La versión completa usaría Jupiter Python SDK para construir la transacción, firmarla con `solana.Keypair` y enviarla mediante `client.send_raw_transaction`.
 
 ### 5.4 Logger / Console UI
-- `rich` para tabla en vivo con: timestamp, par, tipo, qty, precio, fee, P/L  
-- Historial persistente en `logs/trades.csv`
+- `utils/logger.py` configura el logging con `rich` y guarda cada trade en `logs/trades.csv`.
+- `utils/backtest.py` permite pruebas rápidas de la estrategia con datos históricos simulados.
 
 ---
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -18,3 +18,9 @@ Implemented base structure with config loader and price fetch from Jupiter API.
 - Created `strategy/simple_strategy.py` with a basic signal generator.
 - Updated `main.py` to collect recent prices and print the generated signal.
 - Documented new modules in README.
+
+## Step 4
+- Implemented stubbed Jupiter client in `execution/jupiter_client.py`.
+- Created `execution/portfolio.py` for basic position tracking.
+- Added `utils/logger.py` and `utils/backtest.py` with simple helpers.
+- Updated README with new module descriptions.

--- a/src/execution/jupiter_client.py
+++ b/src/execution/jupiter_client.py
@@ -1,0 +1,39 @@
+import aiohttp
+from typing import Optional, Dict
+
+
+API_URL = "https://quote-api.jup.ag/v6/quote"
+
+async def request_quote(
+    input_mint: str,
+    output_mint: str,
+    amount: int,
+    slippage_bps: int = 50,
+) -> Optional[Dict]:
+    """Fetch a swap quote from the Jupiter aggregator.
+
+    Returns the JSON response with route information or ``None`` if the
+    request fails (for example due to missing network access).
+    """
+    params = {
+        "inputMint": input_mint,
+        "outputMint": output_mint,
+        "amount": amount,
+        "slippageBps": slippage_bps,
+    }
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(API_URL, params=params) as resp:
+                if resp.status != 200:
+                    return None
+                return await resp.json()
+    except Exception:
+        # Network access might not be available in some environments.
+        return None
+
+
+async def execute_swap(quote: Dict) -> bool:
+    """Placeholder to sign and send the transaction built from a quote."""
+    # The real implementation would use the Jupiter SDK and solana-py to
+    # build and send the transaction. This is left as a stub for now.
+    return False

--- a/src/execution/portfolio.py
+++ b/src/execution/portfolio.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Portfolio:
+    """Simple in-memory portfolio tracker."""
+
+    base_symbol: str = "SOL"
+    quote_symbol: str = "USDC"
+    base_balance: float = 0.0
+    quote_balance: float = 0.0
+
+    def update_from_trade(self, side: str, quantity: float, price: float, fee: float = 0.0) -> None:
+        """Update balances after executing a trade."""
+        if side.upper() == "BUY":
+            self.base_balance += quantity
+            self.quote_balance -= quantity * price + fee
+        elif side.upper() == "SELL":
+            self.base_balance -= quantity
+            self.quote_balance += quantity * price - fee
+
+    @property
+    def value_usd(self) -> float:
+        """Return portfolio value in USD based on quote balance only."""
+        return self.quote_balance
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            self.base_symbol: self.base_balance,
+            self.quote_symbol: self.quote_balance,
+        }

--- a/src/utils/backtest.py
+++ b/src/utils/backtest.py
@@ -1,0 +1,42 @@
+"""Simple back-testing helper for the strategy."""
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from src.strategy.simple_strategy import generate_signal
+from src.execution.portfolio import Portfolio
+
+
+@dataclass
+class BacktestResult:
+    returns: float
+    trades: int
+
+
+def run_backtest(price_series: Iterable[float], starting_cash: float = 1000.0) -> BacktestResult:
+    prices: List[float] = list(price_series)
+    portfolio = Portfolio(quote_balance=starting_cash)
+    trades = 0
+
+    for i in range(50, len(prices)):
+        window = prices[: i + 1]
+        signal = generate_signal(window)
+        price = prices[i]
+        qty = 1  # fixed 1 SOL for demo
+        if signal == "BUY" and portfolio.quote_balance >= price:
+            portfolio.update_from_trade("BUY", qty, price)
+            trades += 1
+        elif signal == "SELL" and portfolio.base_balance >= qty:
+            portfolio.update_from_trade("SELL", qty, price)
+            trades += 1
+
+    return BacktestResult(returns=portfolio.quote_balance - starting_cash, trades=trades)
+
+
+def export_report(result: BacktestResult, path: Path) -> None:
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["returns", "trades"])
+        writer.writerow([result.returns, result.trades])

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,0 +1,30 @@
+import csv
+import logging
+from pathlib import Path
+from typing import Dict
+
+from rich.logging import RichHandler
+
+
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
+LOG_FILE = LOG_DIR / "trades.csv"
+
+
+def setup_logger() -> logging.Logger:
+    """Configure a basic logger with rich formatting."""
+    logger = logging.getLogger("bot")
+    logger.setLevel(logging.INFO)
+    handler = RichHandler(markup=True)
+    logger.addHandler(handler)
+    return logger
+
+
+def log_trade(data: Dict[str, str]) -> None:
+    """Append trade information to the CSV log."""
+    write_header = not LOG_FILE.exists()
+    with LOG_FILE.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=data.keys())
+        if write_header:
+            writer.writeheader()
+        writer.writerow(data)


### PR DESCRIPTION
## Summary
- implement stubbed Jupiter client and portfolio tracker
- add rich logger and simple backtest helper
- document new modules and update development log

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851bc90c1188320a6cf52c5e9d907b3