### PR TITLE
Implement trading loop with mock feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ solana-ai-bot/
 ├─ requirements.txt        ← librerías Python
 ├─ .env.example            ← plantilla de variables
 └─ src/
+   ├─ bot.py               ← loop principal
    ├─ main.py              ← punto de entrada
    ├─ config.py
    ├─ data/
    │  ├─ pyth_feed.py
-   │  └─ jupiter_quote.py
+   │  ├─ jupiter_quote.py
+   │  └─ mock_feed.py      ← feed simulado
    ├─ strategy/
    │  ├─ indicators.py
    │  ├─ model.py          ← ML ligero (opcional)
@@ -121,6 +123,7 @@ MAX_DRAWDOWN_PCT=20
 |--------|-----|----------------|
 | **Jupiter API** | Cotizaciones instantáneas + rutas de swap | `src/data/jupiter_quote.py` |
 | **Pyth Network** | Precio fiable on-chain (SOL/USD) | WebSocket vía `pyth-client-py` |
+| **Mock Feed** | Generación local de precios | `src/data/mock_feed.py` |
 
 ### 5.2 Strategy
 - **Indicadores técnicos (EMA 12/50, RSI 14, Bollinger 20/2)**
@@ -137,6 +140,9 @@ MAX_DRAWDOWN_PCT=20
 ### 5.4 Logger / Console UI
 - `utils/logger.py` configura el logging con `rich` y guarda cada trade en `logs/trades.csv`.
 - `utils/backtest.py` permite pruebas rápidas de la estrategia con datos históricos simulados.
+
+### 5.5 Trading loop
+- `bot.TradingBot` integra feed, estrategia y cartera en un loop asíncrono.
 
 ---
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -24,3 +24,9 @@ Implemented base structure with config loader and price fetch from Jupiter API.
 - Created `execution/portfolio.py` for basic position tracking.
 - Added `utils/logger.py` and `utils/backtest.py` with simple helpers.
 - Updated README with new module descriptions.
+
+## Step 5
+- Added `data/mock_feed.py` with a random-walk price generator for offline tests.
+- Implemented `TradingBot` class orchestrating feed, strategy and portfolio.
+- Simplified `main.py` to run the bot for a short demo.
+- Documented new modules and trading loop in README.

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,0 +1,41 @@
+import asyncio
+from typing import List
+
+from src.data.mock_feed import MockPriceFeed
+from src.strategy.simple_strategy import generate_signal
+from src.execution.portfolio import Portfolio
+from src.utils.logger import setup_logger, log_trade
+
+
+class TradingBot:
+    """Orchestrates price feed, strategy and portfolio."""
+
+    def __init__(self, starting_cash: float = 1000.0):
+        self.feed = MockPriceFeed()
+        self.portfolio = Portfolio(quote_balance=starting_cash)
+        self.logger = setup_logger()
+        self.prices: List[float] = []
+
+    async def step(self) -> None:
+        price = await self.feed.get_price()
+        self.prices.append(price)
+        self.logger.info(f"Price: {price} USD")
+        signal = generate_signal(self.prices)
+
+        if signal == "BUY" and self.portfolio.quote_balance >= price:
+            self.portfolio.update_from_trade("BUY", 1, price)
+            log_trade({"side": "BUY", "price": price})
+            self.logger.info(f"Executed BUY @ {price}")
+        elif signal == "SELL" and self.portfolio.base_balance >= 1:
+            self.portfolio.update_from_trade("SELL", 1, price)
+            log_trade({"side": "SELL", "price": price})
+            self.logger.info(f"Executed SELL @ {price}")
+        else:
+            self.logger.info("No trade executed")
+
+        self.logger.info(f"Balances: {self.portfolio.as_dict()}")
+
+    async def run(self, steps: int = 50, interval: float = 1.0) -> None:
+        for _ in range(steps):
+            await self.step()
+            await asyncio.sleep(interval)

--- a/src/data/mock_feed.py
+++ b/src/data/mock_feed.py
@@ -1,0 +1,14 @@
+import random
+
+class MockPriceFeed:
+    """Simple random walk price generator for offline testing."""
+
+    def __init__(self, start_price: float = 100.0, volatility: float = 0.02):
+        self.price = start_price
+        self.volatility = volatility
+
+    async def get_price(self) -> float:
+        """Return next price tick."""
+        change = random.uniform(-self.volatility, self.volatility)
+        self.price *= 1 + change
+        return round(self.price, 4)

--- a/src/main.py
+++ b/src/main.py
@@ -1,32 +1,10 @@
 import asyncio
-from rich import print
-
-from src.data.jupiter_quote import fetch_sol_price
-from src.data.pyth_feed import fetch_pyth_sol_price
-from src.strategy.simple_strategy import generate_signal
-
-
-async def gather_prices(count: int = 10, interval: float = 1.0):
-    """Fetch SOL prices multiple times and return the list."""
-    prices = []
-    for _ in range(count):
-        price = await fetch_sol_price()
-        if price is not None:
-            prices.append(price)
-            print(f"[cyan]Jupiter price:[/] {price} USD")
-        else:
-            print("[red]Failed to fetch Jupiter price[/]")
-        await asyncio.sleep(interval)
-    return prices
+from src.bot import TradingBot
 
 
 async def main():
-    prices = await gather_prices()
-    pyth_price = await fetch_pyth_sol_price()
-    if pyth_price is not None:
-        print(f"[green]Latest Pyth price:[/] {pyth_price} USD")
-    signal = generate_signal(prices)
-    print(f"[bold yellow]Generated signal:[/] {signal}")
+    bot = TradingBot()
+    await bot.run(steps=10, interval=1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `MockPriceFeed` for offline price generation
- create `TradingBot` orchestrator
- simplify `main.py` to run the bot
- document new modules in README and devlog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851bea50a94832091cf1bf99c3168f0